### PR TITLE
chore: try to change agent pool

### DIFF
--- a/azure-pipelines/cd.yml
+++ b/azure-pipelines/cd.yml
@@ -16,6 +16,7 @@ strategy:
 
 pool:
   vmImage: $(imageName)
+  demands: npm
 
 variables:
 - template: common/variables.yml

--- a/azure-pipelines/ci.yml
+++ b/azure-pipelines/ci.yml
@@ -19,6 +19,7 @@ strategy:
 
 pool:
   vmImage: $(imageName)
+  demands: npm
 
 steps:
 

--- a/azure-pipelines/nightly_build.yml
+++ b/azure-pipelines/nightly_build.yml
@@ -20,6 +20,7 @@ strategy:
 
 pool:
   vmImage: $(imageName)
+  demands: npm
 
 variables:
 - template: common/variables.yml


### PR DESCRIPTION
Currently, all pipelines run on "Azure Pipelines" pool, but workbench seems run on different pool by different os.
Try to follow workbench.