### PR TITLE
Pipeline updates

### DIFF
--- a/azure-pipelines/analysis.yml
+++ b/azure-pipelines/analysis.yml
@@ -1,0 +1,37 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+
+# Required for schedule only trigger
+trigger: none
+pr: none
+
+# Run weekly at midnight (Pacific).
+schedules:
+- cron: "0 8 * * 1"
+  displayName: 'Weekly Static Analysis'
+  branches:
+    include:
+    - develop
+
+variables:
+  LGTM.UploadSnapshot: true
+  Semmle.SkipAnalysis: true
+
+stages:
+  - stage: 'staticAnalysis'
+    displayName: 'Static Analysis'
+    jobs:
+      - job: 'codeQL'
+        displayName: 'Execute CodeQL Analysis'
+        pool:
+          vmImage: 'windows-2019'
+        steps:
+          - task: Semmle@1
+            inputs:
+              sourceCodeDirectory: '$(Build.SourcesDirectory)'
+              language: 'tsandjs'
+              querySuite: 'Recommended'
+              timeout: '1800'
+              ram: '16384'
+              addProjectDirToScanningExclusionList: true
+            env:
+              System_AccessToken: $(System.AccessToken)

--- a/azure-pipelines/analysis.yml
+++ b/azure-pipelines/analysis.yml
@@ -10,7 +10,7 @@ schedules:
   displayName: 'Weekly Static Analysis'
   branches:
     include:
-    - develop
+    - main
 
 variables:
   LGTM.UploadSnapshot: true

--- a/azure-pipelines/cd.yml
+++ b/azure-pipelines/cd.yml
@@ -11,16 +11,20 @@ parameters:
   displayName: 'Build agent image'
   type: string
   default: 'BuildAgentImage'
+- name: aiKeyVar
+  displayName: 'AI Key Variable'
+  type: string
+  default: 'TestAIKey'
 - name: ghRelease
   displayName: 'Draft github release'
   type: boolean
   default: false
-- name: isPreRelease
-  displayName: 'PreRelease / release candidate build'
-  type: boolean
-  default: false
 - name: publishExt
   displayName: 'Publish to Marketplace'
+  type: boolean
+  default: false
+- name: productionRelease
+  displayName: 'Release to marketplace as public (non-preview)'
   type: boolean
   default: false
 
@@ -30,6 +34,8 @@ variables:
   value: $[variables.${{ parameters.buildAgentVmImageVar }}]
 - name: buildPool
   value: $[variables.${{ parameters.buildAgentPoolVar }}]
+- name: aiKey
+  value: $[variables.${{ parameters.aiKeyVar }}]
 
 stages:
 - stage: test
@@ -99,17 +105,15 @@ stages:
 
       # modify application insights key for releases
       - script: |
-          node scripts/modifyPackageJson.js aiKey $ENV_AIKEY
+          node scripts/modifyPackageJson.js aiKey $(aiKey)
         displayName: Modify package.json for releases
-        condition: and(succeeded(), eq(${{ parameters.publishExt }}, True))
-        env:
-          ENV_AIKEY: $(PROD_AIKEY)
+        condition: and(succeeded(), ${{ parameters.publishExt }})
 
       - template: common/package_steps.yml
       
       - task: PowerShell@2
         name: 'getVersion'
-        condition: eq(${{ parameters.ghRelease }}, true)
+        condition: ${{ parameters.ghRelease }}
         displayName: Scrape tag from package.json
         inputs:
           targetType: inline
@@ -151,16 +155,16 @@ stages:
           title: Release $(versionTag)
           tag: $(versionTag)
           isDraft: true
-          isPreRelease: ${{ parameters.isPreRelease }}
+          isPreRelease: ${{ not(parameters.productionRelease) }}
           assets: '$(System.ArtifactsDirectory)/vsix/*.vsix'
-        condition: and(succeeded(), eq(${{ parameters.ghRelease }}, true))
+        condition: and(succeeded(), ${{ parameters.ghRelease }})
 
       # publish pre-release vsix to marketplace
       - bash: |
           vsce publish -p $MARKETPLACE_TOKEN --packagePath *.vsix --pre-release
         workingDirectory: '$(System.ArtifactsDirectory)/vsix'
         displayName: Deploy pre-release VSIX to marketplace
-        condition: and(succeeded(), eq(${{ parameters.publishExt }}, True), eq(${{ parameters.isPreRelease }}, True))
+        condition: and(succeeded(), ${{ parameters.publishExt }}, not(${{ parameters.productionRelease }}))
         env:
           MARKETPLACE_TOKEN: $(vsciot_marketplace_token)
 
@@ -169,6 +173,6 @@ stages:
           vsce publish -p $MARKETPLACE_TOKEN --packagePath *.vsix
         workingDirectory: '$(System.ArtifactsDirectory)/vsix'
         displayName: Deploy release VSIX to marketplace
-        condition: and(succeeded(), eq(${{ parameters.publishExt }}, True), eq(${{ parameters.isPreRelease }}, False))
+        condition: and(succeeded(), ${{ parameters.publishExt }}, ${{ parameters.productionRelease }})
         env:
           MARKETPLACE_TOKEN: $(vsciot_marketplace_token)

--- a/azure-pipelines/cd.yml
+++ b/azure-pipelines/cd.yml
@@ -162,7 +162,7 @@ stages:
 
       # publish pre-release vsix to marketplace
       - bash: |
-          vsce publish -p $MARKETPLACE_TOKEN --packagePath *.vsix
+          vsce publish -p $MARKETPLACE_TOKEN --packagePath *.vsix --pre-release
         workingDirectory: '$(System.ArtifactsDirectory)/vsix'
         displayName: Deploy pre-release VSIX to marketplace
         condition: and(succeeded(), eq(${{ parameters.publishExt }}, True), eq(${{ parameters.isPreRelease }}, True))
@@ -171,7 +171,7 @@ stages:
 
       # publish vsix to marketplace
       - bash: |
-          vsce publish -p $MARKETPLACE_TOKEN --packagePath *.vsix --pre-release
+          vsce publish -p $MARKETPLACE_TOKEN --packagePath *.vsix
         workingDirectory: '$(System.ArtifactsDirectory)/vsix'
         displayName: Deploy release VSIX to marketplace
         condition: and(succeeded(), eq(${{ parameters.publishExt }}, True), eq(${{ parameters.isPreRelease }}, False))

--- a/azure-pipelines/cd.yml
+++ b/azure-pipelines/cd.yml
@@ -56,14 +56,11 @@ stages:
 
 - stage: release
   dependsOn: [test]
-  pool:
-    name: $[variables.${{ parameters.buildAgentPoolVar }}]
-    vmImage: $(vmImage)
-    demands:
-      - ImageOverride -equals $(vmImage)
   jobs:
   - job: CredScan
     displayName: 'Credential Scan'
+    pool:
+      vmImage: windows-latest
     steps:
     - task: CredScan@3
       inputs:
@@ -89,6 +86,11 @@ stages:
 
   - job: package_and_release
     displayName: 'Package and Release'
+    pool:
+      name: $[variables.${{ parameters.buildAgentPoolVar }}]
+      vmImage: $(vmImage)
+      demands:
+        - ImageOverride -equals $(vmImage)
     dependsOn: CredScan
     steps:
       - template: common/setup_steps.yml

--- a/azure-pipelines/cd.yml
+++ b/azure-pipelines/cd.yml
@@ -5,60 +5,74 @@ trigger:
 
 pr: none
 
-strategy:
-  matrix:
-    linux:
-      imageName: 'ubuntu-16.04'
-    mac:
-      imageName: 'macos-10.14'
-    windows:
-      imageName: 'vs2017-win2016'
-
-pool:
-  vmImage: $(imageName)
-
 variables:
 - template: common/variables.yml
+- group: releaseVariables
 
-steps:
+stages:
+- stage: test
+  jobs:
+  - job: test
+    strategy:
+      matrix:
+        linux:
+          imageName: 'ubuntu-latest'
+        mac:
+          imageName: 'macos-latest'
+        windows:
+          imageName: 'windows-latest'
+    pool:
+      vmImage: $(imageName)
+    steps:
+      - template: common/setup_steps.yml
+      - template: common/compile_steps.yml
+      - template: common/check_steps.yml
+      - template: common/test_steps.yml
 
-  - template: common/setup_steps.yml
-  - template: common/compile_steps.yml
-  - template: common/check_steps.yml
-  - template: common/test_steps.yml
+- stage: release
+  dependsOn: [test]
+  jobs:
+  - job: release
+    pool:
+      name: $(BuildAgentPool)
+      vmImage: $(BuildAgentImage)
+    steps:
+      - template: common/setup_steps.yml
+      - template: common/compile_steps.yml
+      - template: common/check_steps.yml
+      - template: common/test_steps.yml
+      - template: common/set_release_flags_steps.yml
 
-  - template: common/set_release_flags_steps.yml
+      # modify package.json for release candidates
+      # including k/v pairs in cli arguments, remove trailing -rc if presents
+      - script: |
+          node scripts/modifyPackageJson.js name $(test_extension_name) displayName "$(test_display_name)" aiKey ${TEST_AIKEY} publisher $(test_publisher)
+        displayName: Modify package.json for release candidates
+        condition: and(succeeded(), eq(variables['is_rc'], 'true'))
 
-  # modify package.json for release candidates
-  # including k/v pairs in cli arguments, remove trailing -rc if presents
-  - script: |
-      node scripts/modifyPackageJson.js name $(test_extension_name) displayName "$(test_display_name)" aiKey ${TEST_AIKEY} publisher $(test_publisher)
-    displayName: Modify package.json for release candidates
-    condition: and(succeeded(), eq(variables['is_rc'], 'true'))
+      # modify package.json for releases
+      # including k/v pairs in cli arguments, remove trailing -rc if presents
+      - script: |
+          node scripts/modifyPackageJson.js aiKey ${PROD_AIKEY}
+        displayName: Modify package.json for release candidates
+        condition: and(succeeded(), eq(variables['is_r'], 'true'))
 
-  # modify package.json for releases
-  # including k/v pairs in cli arguments, remove trailing -rc if presents
-  - script: |
-      node scripts/modifyPackageJson.js aiKey ${PROD_AIKEY}
-    displayName: Modify package.json for release candidates
-    condition: and(succeeded(), eq(variables['is_r'], 'true'))
+      - template: common/package_steps.yml
 
-  - template: common/package_steps.yml
+      - task: GitHubRelease@0
+        displayName: Deploy Releases or Release Candidates to GitHub Release
+        inputs:
+          gitHubConnection: $(GithubReleaseConnection)'
+          repositoryName: '$(Build.Repository.Name)'
+          action: 'create'
+          target: '$(Build.SourceVersion)'
+          isPreRelease: $(is_rc)
+        condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 
-  - task: GitHubRelease@0
-    displayName: Deploy Releases or Release Candidates to GitHub Release
-    inputs:
-      gitHubConnection: 'vsciotci_github_pat_pnp_authoring'
-      repositoryName: '$(Build.Repository.Name)'
-      action: 'create'
-      target: '$(Build.SourceVersion)'
-      isPreRelease: $(is_rc)
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
-
-  # publish vsix to marketplace for releases
-  - bash: vsce publish -p $MARKETPLACE_TOKEN --packagePath *.vsix
-    workingDirectory: '$(Build.ArtifactStagingDirectory)'
-    displayName: Deploy releases to marketplace
-    condition: and(succeeded(), eq(variables['is_r'], 'true'), eq(variables['Agent.OS'], 'Linux'))
-    env:
-      MARKETPLACE_TOKEN: $(vsciot_marketplace_token)
+      # publish vsix to marketplace for releases
+      - bash: vsce publish -p $MARKETPLACE_TOKEN --packagePath *.vsix
+        workingDirectory: '$(Build.ArtifactStagingDirectory)'
+        displayName: Deploy releases to marketplace
+        condition: and(succeeded(), eq(variables['is_r'], 'true'), eq(variables['Agent.OS'], 'Linux'))
+        env:
+          MARKETPLACE_TOKEN: $(vsciot_marketplace_token)

--- a/azure-pipelines/cd.yml
+++ b/azure-pipelines/cd.yml
@@ -102,7 +102,7 @@ stages:
       - script: |
           node scripts/modifyPackageJson.js name $(test_extension_name) displayName "$(test_display_name)" aiKey $ENV_AIKEY publisher $(test_publisher)
         displayName: Modify package.json for release candidates
-        condition: and(succeeded(), eq(${{ parameters.isPreRelease }}, true), eq(${{ parameters.publishExt }}, false))
+        condition: and(succeeded(), eq(${{ parameters.isPreRelease }}, true))
         env:
           ENV_AIKEY: $(TEST_AIKEY)
 
@@ -110,7 +110,7 @@ stages:
       - script: |
           node scripts/modifyPackageJson.js aiKey $ENV_AIKEY
         displayName: Modify package.json for releases
-        condition: and(succeeded(), eq(${{ parameters.publishExt }}, true), eq(${{ parameters.isPreRelease }}, false))
+        condition: and(succeeded(), eq(${{ parameters.isPreRelease }}, false))
         env:
           ENV_AIKEY: $(PROD_AIKEY)
 

--- a/azure-pipelines/cd.yml
+++ b/azure-pipelines/cd.yml
@@ -46,16 +46,20 @@ stages:
       # modify package.json for release candidates
       # including k/v pairs in cli arguments, remove trailing -rc if presents
       - script: |
-          node scripts/modifyPackageJson.js name $(test_extension_name) displayName "$(test_display_name)" aiKey ${TEST_AIKEY} publisher $(test_publisher)
+          node scripts/modifyPackageJson.js name $(test_extension_name) displayName "$(test_display_name)" aiKey $ENV_AIKEY publisher $(test_publisher)
         displayName: Modify package.json for release candidates
         condition: and(succeeded(), eq(variables['is_rc'], 'true'))
+        env:
+          ENV_AIKEY: $(TEST_AIKEY)
 
       # modify package.json for releases
       # including k/v pairs in cli arguments, remove trailing -rc if presents
       - script: |
-          node scripts/modifyPackageJson.js aiKey ${PROD_AIKEY}
-        displayName: Modify package.json for release candidates
+          node scripts/modifyPackageJson.js aiKey $ENV_AIKEY
+        displayName: Modify package.json for releases
         condition: and(succeeded(), eq(variables['is_r'], 'true'))
+        env:
+          ENV_AIKEY: $(PROD_AIKEY)
 
       - template: common/package_steps.yml
 

--- a/azure-pipelines/cd.yml
+++ b/azure-pipelines/cd.yml
@@ -31,6 +31,8 @@ parameters:
 variables:
 - template: common/variables.yml
 - group: ${{ parameters.variableGroup }}
+- name: vmImage
+  value: $[variables.${{ parameters.buildAgentVmImageVar }}]
 
 stages:
 - stage: test
@@ -54,17 +56,45 @@ stages:
 
 - stage: release
   dependsOn: [test]
+  pool:
+    name: $[variables.${{ parameters.buildAgentPoolVar }}]
+    vmImage: $(vmImage)
+    demands:
+      - ImageOverride -equals $(vmImage)
   jobs:
-  - job: release
-    pool:
-      name: $[variables.${{ parameters.buildAgentPoolVar }}]
-      vmImage: $[variables.${{ parameters.buildAgentVmImageVar }}]
+  - job: CredScan
+    displayName: 'Credential Scan'
+    steps:
+    - task: CredScan@3
+      inputs:
+        outputFormat: 'pre'
+        scanFolder: '$(Build.SourcesDirectory)'
+
+    - task: PostAnalysis@1
+      inputs:
+        AllTools: false
+        APIScan: false
+        BinSkim: false
+        CodesignValidation: false
+        CredScan: true
+        FortifySCA: false
+        FxCop: false
+        ModernCop: false
+        PoliCheck: false
+        RoslynAnalyzers: false
+        SDLNativeRules: false
+        Semmle: false
+        TSLint: false
+        ToolLogsNotFoundAction: 'Standard'
+
+  - job: package_and_release
+    displayName: 'Package and Release'
+    dependsOn: CredScan
     steps:
       - template: common/setup_steps.yml
       - template: common/compile_steps.yml
       - template: common/check_steps.yml
       - template: common/test_steps.yml
-      - template: common/set_release_flags_steps.yml
 
       # modify package.json for release candidates
       - script: |

--- a/azure-pipelines/cd.yml
+++ b/azure-pipelines/cd.yml
@@ -15,16 +15,12 @@ parameters:
   displayName: 'AI Key Variable'
   type: string
   default: 'TestAIKey'
-- name: ghRelease
-  displayName: 'Draft github release'
-  type: boolean
-  default: false
 - name: publishExt
   displayName: 'Publish to Marketplace'
   type: boolean
   default: false
 - name: productionRelease
-  displayName: 'Release to marketplace as public (non-preview)'
+  displayName: 'Publish to marketplace as public (non-preview)'
   type: boolean
   default: false
 
@@ -110,19 +106,9 @@ stages:
         condition: and(succeeded(), ${{ parameters.publishExt }})
 
       - template: common/package_steps.yml
-      
-      - task: PowerShell@2
-        name: 'getVersion'
-        condition: ${{ parameters.ghRelease }}
-        displayName: Scrape tag from package.json
-        inputs:
-          targetType: inline
-          script: |
-            $packageVersion = npm version | ConvertFrom-Json | Select-Object -ExpandProperty {vscode-dtdl}
-            echo "##vso[task.setvariable variable=versionTag;isOutput=true]v$packageVersion"
 
 - stage: release
-  displayName: 'Release to Github and VS Marketplace'
+  displayName: 'Release to VS Marketplace'
   dependsOn: [test, build]
   pool:
     name: $(buildPool)
@@ -135,8 +121,6 @@ stages:
     environment: 'production'
   - job: 'release'
     displayName: 'Release package'
-    variables:
-      versionTag: $[ stageDependencies.build.build_and_package.outputs['getVersion.versionTag'] ]
     steps:
       - task: DownloadPipelineArtifact@2
         displayName : 'Download VSIX Build Artifacts'
@@ -144,20 +128,6 @@ stages:
           source: 'current'
           artifact: 'vscode-dtdl'
           path: '$(System.ArtifactsDirectory)/vsix'
-
-      - task: GitHubRelease@1
-        displayName: 'Deploy Release to GitHub'
-        inputs:
-          gitHubConnection: $(GithubReleaseConnection)
-          repositoryName: '$(Build.Repository.Name)'
-          action: 'create'
-          tagSource: userSpecifiedTag
-          title: Release $(versionTag)
-          tag: $(versionTag)
-          isDraft: true
-          isPreRelease: ${{ not(parameters.productionRelease) }}
-          assets: '$(System.ArtifactsDirectory)/vsix/*.vsix'
-        condition: and(succeeded(), ${{ parameters.ghRelease }})
 
       # publish pre-release vsix to marketplace
       - bash: |

--- a/azure-pipelines/cd.yml
+++ b/azure-pipelines/cd.yml
@@ -1,13 +1,36 @@
-trigger:
-  tags:
-    include:
-    - v*
-
+# Manual trigger only
+trigger: none
 pr: none
+
+parameters:
+- name: variableGroup
+  displayName: 'Pipeline variable group'
+  type: string
+  default: 'releaseVariables'
+- name: buildAgentPoolVar
+  displayName: 'Build agent pool'
+  type: string
+  default: 'BuildAgentPool'
+- name: buildAgentVmImageVar
+  displayName: 'Build agent image'
+  type: string
+  default: 'BuildAgentImage'
+- name: ghRelease
+  displayName: 'Draft github release'
+  type: boolean
+  default: false
+- name: isPreRelease
+  displayName: 'PreRelease / release candidate build'
+  type: boolean
+  default: false
+- name: publishExt
+  displayName: 'Publish to Marketplace'
+  type: boolean
+  default: false
 
 variables:
 - template: common/variables.yml
-- group: releaseVariables
+- group: ${{ parameters.variableGroup }}
 
 stages:
 - stage: test
@@ -34,8 +57,8 @@ stages:
   jobs:
   - job: release
     pool:
-      name: $(BuildAgentPool)
-      vmImage: $(BuildAgentImage)
+      name: $[variables.${{ parameters.buildAgentPoolVar }}]
+      vmImage: $[variables.${{ parameters.buildAgentVmImageVar }}]
     steps:
       - template: common/setup_steps.yml
       - template: common/compile_steps.yml
@@ -47,7 +70,7 @@ stages:
       - script: |
           node scripts/modifyPackageJson.js name $(test_extension_name) displayName "$(test_display_name)" aiKey $ENV_AIKEY publisher $(test_publisher)
         displayName: Modify package.json for release candidates
-        condition: and(succeeded(), eq(variables['is_rc'], 'true'))
+        condition: and(succeeded(), eq(${{ parameters.isPreRelease }}, 'true'), eq(${{ parameters.publishExt }}, 'false'))
         env:
           ENV_AIKEY: $(TEST_AIKEY)
 
@@ -55,12 +78,21 @@ stages:
       - script: |
           node scripts/modifyPackageJson.js aiKey $ENV_AIKEY
         displayName: Modify package.json for releases
-        condition: and(succeeded(), eq(variables['is_r'], 'true'))
+        condition: and(succeeded(), eq(${{ parameters.publishExt }}, 'true'), eq(${{ parameters.isPreRelease }}, 'false'))
         env:
           ENV_AIKEY: $(PROD_AIKEY)
 
       - template: common/package_steps.yml
-
+      
+      - task: PowerShell@2
+        condition: eq(${{ parameters.ghRelease }}, 'true')
+        displayName: Scrape tag from package.json
+        inputs:
+          targetType: inline
+          script: |
+            $packageVersion = npm version | ConvertFrom-Json | Select-Object -ExpandProperty {vscode-dtdl}
+            echo "##vso[task.setvariable variable=versionTag]v$packageVersion"
+      
       - task: GitHubRelease@1
         displayName: Deploy Releases or Release Candidates to GitHub Release
         inputs:
@@ -68,15 +100,16 @@ stages:
           repositoryName: '$(Build.Repository.Name)'
           action: 'create'
           tagSource: userSpecifiedTag
-          tag: $(Build.SourceBranchName)
+          title: Release $(versionTag)
+          tag: $(versionTag)
           isDraft: true
-          isPreRelease: $(is_rc)
-        condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
+          isPreRelease: ${{ parameters.isPreRelease }}
+        condition: and(succeeded(), eq(${{ parameters.ghRelease }}, 'true'))
 
       # publish vsix to marketplace for releases
       - bash: vsce publish -p $MARKETPLACE_TOKEN --packagePath *.vsix
         workingDirectory: '$(Build.ArtifactStagingDirectory)'
         displayName: Deploy releases to marketplace
-        condition: and(succeeded(), eq(variables['is_r'], 'true'), eq(variables['Agent.OS'], 'Linux'))
+        condition: and(succeeded(), eq(${{ parameters.publishExt }}, 'true'), eq(${{ parameters.isPreRelease }}, 'false'))
         env:
           MARKETPLACE_TOKEN: $(vsciot_marketplace_token)

--- a/azure-pipelines/cd.yml
+++ b/azure-pipelines/cd.yml
@@ -33,11 +33,15 @@ variables:
 - group: ${{ parameters.variableGroup }}
 - name: vmImage
   value: $[variables.${{ parameters.buildAgentVmImageVar }}]
+- name: buildPool
+  value: $[variables.${{ parameters.buildAgentPoolVar }}]
 
 stages:
 - stage: test
+  displayName: 'Test'
   jobs:
-  - job: test
+  - job: run_tests
+    displayName: 'Run tests'
     strategy:
       matrix:
         linux:
@@ -54,7 +58,7 @@ stages:
       - template: common/check_steps.yml
       - template: common/test_steps.yml
 
-- stage: release
+- stage: build
   dependsOn: [test]
   jobs:
   - job: CredScan
@@ -84,10 +88,10 @@ stages:
         TSLint: false
         ToolLogsNotFoundAction: 'Standard'
 
-  - job: package_and_release
-    displayName: 'Package and Release'
+  - job: build_and_package
+    displayName: 'Build and Publish Artifacts'
     pool:
-      name: $[variables.${{ parameters.buildAgentPoolVar }}]
+      name: $(buildPool)
       vmImage: $(vmImage)
       demands:
         - ImageOverride -equals $(vmImage)
@@ -98,33 +102,50 @@ stages:
       - template: common/check_steps.yml
       - template: common/test_steps.yml
 
-      # modify package.json for release candidates
-      - script: |
-          node scripts/modifyPackageJson.js name $(test_extension_name) displayName "$(test_display_name)" aiKey $ENV_AIKEY publisher $(test_publisher)
-        displayName: Modify package.json for release candidates
-        condition: and(succeeded(), eq(${{ parameters.isPreRelease }}, true))
-        env:
-          ENV_AIKEY: $(TEST_AIKEY)
-
-      # modify package.json for releases
+      # modify application insights key for releases
       - script: |
           node scripts/modifyPackageJson.js aiKey $ENV_AIKEY
         displayName: Modify package.json for releases
-        condition: and(succeeded(), eq(${{ parameters.isPreRelease }}, false))
+        condition: and(succeeded(), eq(${{ parameters.publishExt }}, True))
         env:
           ENV_AIKEY: $(PROD_AIKEY)
 
       - template: common/package_steps.yml
       
       - task: PowerShell@2
+        name: 'getVersion'
         condition: eq(${{ parameters.ghRelease }}, true)
         displayName: Scrape tag from package.json
         inputs:
           targetType: inline
           script: |
             $packageVersion = npm version | ConvertFrom-Json | Select-Object -ExpandProperty {vscode-dtdl}
-            echo "##vso[task.setvariable variable=versionTag]v$packageVersion"
-      
+            echo "##vso[task.setvariable variable=versionTag;isOutput=true]v$packageVersion"
+
+- stage: release
+  displayName: 'Release to Github and VS Marketplace'
+  dependsOn: [test, build]
+  pool:
+    name: $(buildPool)
+    vmImage: $(vmImage)
+    demands:
+      - ImageOverride -equals $(vmImage)
+  jobs:
+  - deployment: 'StageRelease'
+    displayName: 'Stage Release for deployment'
+    environment: 'production'
+  - job: 'release'
+    displayName: 'Release package'
+    variables:
+      versionTag: $[ stageDependencies.build.build_and_package.outputs['getVersion.versionTag'] ]
+    steps:
+      - task: DownloadPipelineArtifact@2
+        displayName : 'Download VSIX Build Artifacts'
+        inputs:
+          source: 'current'
+          artifact: 'vscode-dtdl'
+          path: '$(System.ArtifactsDirectory)/vsix'
+
       - task: GitHubRelease@1
         displayName: Deploy Releases or Release Candidates to GitHub Release
         inputs:
@@ -136,12 +157,23 @@ stages:
           tag: $(versionTag)
           isDraft: true
           isPreRelease: ${{ parameters.isPreRelease }}
+          assets: '$(System.ArtifactsDirectory)/vsix/*.vsix'
         condition: and(succeeded(), eq(${{ parameters.ghRelease }}, true))
 
-      # publish vsix to marketplace for releases
-      - bash: vsce publish -p $MARKETPLACE_TOKEN --packagePath *.vsix
-        workingDirectory: '$(Build.ArtifactStagingDirectory)'
-        displayName: Deploy releases to marketplace
-        condition: and(succeeded(), eq(${{ parameters.publishExt }}, true), eq(${{ parameters.isPreRelease }}, false))
+      # publish pre-release vsix to marketplace
+      - bash: |
+          vsce publish -p $MARKETPLACE_TOKEN --packagePath *.vsix
+        workingDirectory: '$(System.ArtifactsDirectory)/vsix'
+        displayName: Deploy pre-release VSIX to marketplace
+        condition: and(succeeded(), eq(${{ parameters.publishExt }}, True), eq(${{ parameters.isPreRelease }}, True))
+        env:
+          MARKETPLACE_TOKEN: $(vsciot_marketplace_token)
+
+      # publish vsix to marketplace
+      - bash: |
+          vsce publish -p $MARKETPLACE_TOKEN --packagePath *.vsix --pre-release
+        workingDirectory: '$(System.ArtifactsDirectory)/vsix'
+        displayName: Deploy release VSIX to marketplace
+        condition: and(succeeded(), eq(${{ parameters.publishExt }}, True), eq(${{ parameters.isPreRelease }}, False))
         env:
           MARKETPLACE_TOKEN: $(vsciot_marketplace_token)

--- a/azure-pipelines/cd.yml
+++ b/azure-pipelines/cd.yml
@@ -70,7 +70,7 @@ stages:
       - script: |
           node scripts/modifyPackageJson.js name $(test_extension_name) displayName "$(test_display_name)" aiKey $ENV_AIKEY publisher $(test_publisher)
         displayName: Modify package.json for release candidates
-        condition: and(succeeded(), eq(${{ parameters.isPreRelease }}, 'true'), eq(${{ parameters.publishExt }}, 'false'))
+        condition: and(succeeded(), eq(${{ parameters.isPreRelease }}, true), eq(${{ parameters.publishExt }}, false))
         env:
           ENV_AIKEY: $(TEST_AIKEY)
 
@@ -78,14 +78,14 @@ stages:
       - script: |
           node scripts/modifyPackageJson.js aiKey $ENV_AIKEY
         displayName: Modify package.json for releases
-        condition: and(succeeded(), eq(${{ parameters.publishExt }}, 'true'), eq(${{ parameters.isPreRelease }}, 'false'))
+        condition: and(succeeded(), eq(${{ parameters.publishExt }}, true), eq(${{ parameters.isPreRelease }}, false))
         env:
           ENV_AIKEY: $(PROD_AIKEY)
 
       - template: common/package_steps.yml
       
       - task: PowerShell@2
-        condition: eq(${{ parameters.ghRelease }}, 'true')
+        condition: eq(${{ parameters.ghRelease }}, true)
         displayName: Scrape tag from package.json
         inputs:
           targetType: inline
@@ -104,12 +104,12 @@ stages:
           tag: $(versionTag)
           isDraft: true
           isPreRelease: ${{ parameters.isPreRelease }}
-        condition: and(succeeded(), eq(${{ parameters.ghRelease }}, 'true'))
+        condition: and(succeeded(), eq(${{ parameters.ghRelease }}, true))
 
       # publish vsix to marketplace for releases
       - bash: vsce publish -p $MARKETPLACE_TOKEN --packagePath *.vsix
         workingDirectory: '$(Build.ArtifactStagingDirectory)'
         displayName: Deploy releases to marketplace
-        condition: and(succeeded(), eq(${{ parameters.publishExt }}, 'true'), eq(${{ parameters.isPreRelease }}, 'false'))
+        condition: and(succeeded(), eq(${{ parameters.publishExt }}, true), eq(${{ parameters.isPreRelease }}, false))
         env:
           MARKETPLACE_TOKEN: $(vsciot_marketplace_token)

--- a/azure-pipelines/cd.yml
+++ b/azure-pipelines/cd.yml
@@ -44,7 +44,6 @@ stages:
       - template: common/set_release_flags_steps.yml
 
       # modify package.json for release candidates
-      # including k/v pairs in cli arguments, remove trailing -rc if presents
       - script: |
           node scripts/modifyPackageJson.js name $(test_extension_name) displayName "$(test_display_name)" aiKey $ENV_AIKEY publisher $(test_publisher)
         displayName: Modify package.json for release candidates
@@ -53,7 +52,6 @@ stages:
           ENV_AIKEY: $(TEST_AIKEY)
 
       # modify package.json for releases
-      # including k/v pairs in cli arguments, remove trailing -rc if presents
       - script: |
           node scripts/modifyPackageJson.js aiKey $ENV_AIKEY
         displayName: Modify package.json for releases

--- a/azure-pipelines/cd.yml
+++ b/azure-pipelines/cd.yml
@@ -61,13 +61,15 @@ stages:
 
       - template: common/package_steps.yml
 
-      - task: GitHubRelease@0
+      - task: GitHubRelease@1
         displayName: Deploy Releases or Release Candidates to GitHub Release
         inputs:
-          gitHubConnection: $(GithubReleaseConnection)'
+          gitHubConnection: $(GithubReleaseConnection)
           repositoryName: '$(Build.Repository.Name)'
           action: 'create'
-          target: '$(Build.SourceVersion)'
+          tagSource: userSpecifiedTag
+          tag: $(Build.SourceBranchName)
+          isDraft: true
           isPreRelease: $(is_rc)
         condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
 

--- a/azure-pipelines/cd.yml
+++ b/azure-pipelines/cd.yml
@@ -3,10 +3,6 @@ trigger: none
 pr: none
 
 parameters:
-- name: variableGroup
-  displayName: 'Pipeline variable group'
-  type: string
-  default: 'releaseVariables'
 - name: buildAgentPoolVar
   displayName: 'Build agent pool'
   type: string
@@ -30,7 +26,6 @@ parameters:
 
 variables:
 - template: common/variables.yml
-- group: ${{ parameters.variableGroup }}
 - name: vmImage
   value: $[variables.${{ parameters.buildAgentVmImageVar }}]
 - name: buildPool
@@ -147,7 +142,7 @@ stages:
           path: '$(System.ArtifactsDirectory)/vsix'
 
       - task: GitHubRelease@1
-        displayName: Deploy Releases or Release Candidates to GitHub Release
+        displayName: 'Deploy Release to GitHub'
         inputs:
           gitHubConnection: $(GithubReleaseConnection)
           repositoryName: '$(Build.Repository.Name)'

--- a/azure-pipelines/ci.yml
+++ b/azure-pipelines/ci.yml
@@ -12,17 +12,16 @@ pr:
 strategy:
   matrix:
     linux:
-      imageName: 'ubuntu-16.04'
+      imageName: 'ubuntu-latest'
     mac:
-      imageName: 'macos-10.14'
+      imageName: 'macos-latest'
     windows:
-      imageName: 'vs2017-win2016'
+      imageName: 'windows-latest'
 
 pool:
   vmImage: $(imageName)
 
 steps:
-
   - template: common/setup_steps.yml
   - template: common/compile_steps.yml
   - template: common/check_steps.yml

--- a/azure-pipelines/common/package_steps.yml
+++ b/azure-pipelines/common/package_steps.yml
@@ -8,7 +8,12 @@ steps:
   - script: |
       vsce package
     displayName: Build VSIX Package
-
+  
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'Generate Software Manifest'
+    inputs:
+      BuildDropPath: '.'
+  
   - task: CopyFiles@2
     inputs:
       SourceFolder: '$(System.DefaultWorkingDirectory)'

--- a/azure-pipelines/common/package_steps.yml
+++ b/azure-pipelines/common/package_steps.yml
@@ -8,21 +8,19 @@ steps:
   - script: |
       vsce package
     displayName: Build VSIX Package
+
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: '$(System.DefaultWorkingDirectory)'
+      Contents: '**/*.vsix'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
   
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Generate Software Manifest'
     inputs:
-      BuildDropPath: '.'
-  
-  - task: CopyFiles@2
-    inputs:
-      SourceFolder: '$(System.DefaultWorkingDirectory)'
-      Contents: |
-        **/*.vsix
-        **/_manifest/**
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+      BuildDropPath: '$(Build.ArtifactStagingDirectory)'
 
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: $(Agent.OS)-drop
+      artifactName: drop

--- a/azure-pipelines/common/package_steps.yml
+++ b/azure-pipelines/common/package_steps.yml
@@ -20,7 +20,8 @@ steps:
     inputs:
       BuildDropPath: '$(Build.ArtifactStagingDirectory)'
 
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@1
     inputs:
-      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: drop
+      targetPath: '$(Build.ArtifactStagingDirectory)'
+      artifactType: 'pipeline'
+      artifactName: vscode-dtdl

--- a/azure-pipelines/common/package_steps.yml
+++ b/azure-pipelines/common/package_steps.yml
@@ -19,6 +19,7 @@ steps:
       SourceFolder: '$(System.DefaultWorkingDirectory)'
       Contents: |
         **/*.vsix
+        **/_manifest/**
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
   - task: PublishBuildArtifacts@1

--- a/azure-pipelines/common/setup_steps.yml
+++ b/azure-pipelines/common/setup_steps.yml
@@ -6,10 +6,9 @@ steps:
     displayName: Install Node.js
 
   # run npm install
-  - task: Npm@1
-    inputs:
-      verbose: false
-    displayName: Install dependencies
+  - script: |
+      npm ci
+    displayName: 'Install dependencies'
 
   # for what?
   - bash: |

--- a/azure-pipelines/common/setup_steps.yml
+++ b/azure-pipelines/common/setup_steps.yml
@@ -2,7 +2,7 @@ steps:
   # install nodejs
   - task: NodeTool@0
     inputs:
-      versionSpec: '12.13.0'
+      versionSpec: '14.x'
     displayName: Install Node.js
 
   # run npm install

--- a/azure-pipelines/nightly_build.yml
+++ b/azure-pipelines/nightly_build.yml
@@ -4,14 +4,10 @@ schedules:
   branches:
     include:
     - develop
-  always: false # no matter whether there exists a new push to develop, run nightly anyway.
+  always: false
 
 trigger: none
 pr: none
-
-variables:
-- template: common/variables.yml
-- group: releaseVariables
 
 stages:
 - stage: test
@@ -32,23 +28,3 @@ stages:
       - template: common/compile_steps.yml
       - template: common/check_steps.yml
       - template: common/test_steps.yml
-
-- stage: package
-  dependsOn: [test]
-  jobs:
-  - job: package
-    pool:
-      name: $(BuildAgentPool)
-      vmImage: $(BuildAgentImage)
-    steps:
-      - template: common/setup_steps.yml
-      - template: common/compile_steps.yml
-      - template: common/check_steps.yml
-      - template: common/test_steps.yml
-
-      # modify package.json for release candidates
-      # including k/v pairs in cli arguments, remove trailing -rc if presents
-      - script: |
-          node scripts/modifyPackageJson.js name $(nightly_extension_name) displayName "$(nightly_display_name)" aiKey ${TEST_AIKEY} publisher $(nightly_publisher)
-        displayName: Modify package.json for release candidates
-      - template: common/package_steps.yml

--- a/azure-pipelines/nightly_build.yml
+++ b/azure-pipelines/nightly_build.yml
@@ -4,37 +4,51 @@ schedules:
   branches:
     include:
     - develop
-  always: true # no matter whether there exists a new push to develop, run nightly anyway.
+  always: false # no matter whether there exists a new push to develop, run nightly anyway.
 
 trigger: none
 pr: none
 
-strategy:
-  matrix:
-    linux:
-      imageName: 'ubuntu-16.04'
-    mac:
-      imageName: 'macos-10.14'
-    windows:
-      imageName: 'vs2017-win2016'
-
-pool:
-  vmImage: $(imageName)
-
 variables:
 - template: common/variables.yml
+- group: releaseVariables
 
-steps:
+stages:
+- stage: test
+  jobs:
+  - job: test
+    strategy:
+      matrix:
+        linux:
+          imageName: 'ubuntu-latest'
+        mac:
+          imageName: 'macos-latest'
+        windows:
+          imageName: 'windows-latest'
+    pool:
+      vmImage: $(imageName)
+    steps:
+      - template: common/setup_steps.yml
+      - template: common/compile_steps.yml
+      - template: common/check_steps.yml
+      - template: common/test_steps.yml
 
-  - template: common/setup_steps.yml
-  - template: common/compile_steps.yml
-  - template: common/check_steps.yml
-  - template: common/test_steps.yml
+- stage: package
+  dependsOn: [test]
+  jobs:
+  - job: package
+    pool:
+      name: $(BuildAgentPool)
+      vmImage: $(BuildAgentImage)
+    steps:
+      - template: common/setup_steps.yml
+      - template: common/compile_steps.yml
+      - template: common/check_steps.yml
+      - template: common/test_steps.yml
 
-  # modify package.json for release candidates
-  # including k/v pairs in cli arguments, remove trailing -rc if presents
-  - script: |
-      node scripts/modifyPackageJson.js name $(nightly_extension_name) displayName "$(nightly_display_name)" aiKey ${TEST_AIKEY} publisher $(nightly_publisher)
-    displayName: Modify package.json for release candidates
-
-  - template: common/package_steps.yml
+      # modify package.json for release candidates
+      # including k/v pairs in cli arguments, remove trailing -rc if presents
+      - script: |
+          node scripts/modifyPackageJson.js name $(nightly_extension_name) displayName "$(nightly_display_name)" aiKey ${TEST_AIKEY} publisher $(nightly_publisher)
+        displayName: Modify package.json for release candidates
+      - template: common/package_steps.yml


### PR DESCRIPTION
New pipeline - weekly scheduled semantic analysis pipeline

Modified:

- CD pipeline
  - Removed tag trigger in favor of manual trigger
  - Added runtime pipeline parameters for various switches
    - hosted pool params
    - release candidate build / pre-release build
    - github / vs marketplace publish tasks
  - Moved testing matrix into separate stage, release stage runs on single agent in hosted pool
  - Version is obtained from package.json rather than tag
- CI pipeline
  - Updated agent images to latest versions
- Nightly Build
  - Updated agent images to latest versions
  - Set `always` to false - no need to re-run pipeline if no code changes
- Packaging task now has SBOM manifest generation
- Environment setup bumped Node version from 12 to 14 to fix build error.
