### PR TITLE
Prepare for release to use dtdl-language-server v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the `vscode-dtdl` extension will be documented in this file.
 
+## v1.4.1 (2023-07-13)
+
+- Uses `dtdl-language-server` `0.6.1`.
+  - Update string validation for `displayName` and `name` properties in DTDL v2 vs. v3.
+
 ## v1.4.0 (2023-07-12)
 
 - Uses `dtdl-language-server` `0.6.0`, which adds DTDL v3 extensions support.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-dtdl",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2409,9 +2409,9 @@
       }
     },
     "dtdl-language-server": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/dtdl-language-server/-/dtdl-language-server-0.6.0.tgz",
-      "integrity": "sha512-krq0kzoP7PsKZ8SxKWmpbpAGY4OOOaTdu0U6v7N/KaPIa8S41KEPygILoWljolmOa4N/1+913gPxNf7IS85AjA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/dtdl-language-server/-/dtdl-language-server-0.6.1.tgz",
+      "integrity": "sha512-2+jHkNj8cztVAd9Bb07658aBCiLq48/Ap0/MUNzkDD7u1N5KfIusqUYiTtfdtdEqdRjBveyrbil1DuSdx4LsGw==",
       "requires": {
         "commander": "^5.0.0",
         "jsonc-parser": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-dtdl",
   "displayName": "DTDL",
   "description": "This extension provides syntax highlighting to read and edit JSON documents using the Digital Twins Definition Language",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "publisher": "vsciot-vscode",
   "aiKey": "[AIKEY PLACEHOLDER]",
   "icon": "logo.png",
@@ -94,7 +94,7 @@
     "webpack-cli": "^4.7.2"
   },
   "dependencies": {
-    "dtdl-language-server": "0.6.0",
+    "dtdl-language-server": "0.6.1",
     "fs-extra": "^7.0.1",
     "vscode-extension-telemetry": "^0.1.6",
     "vscode-languageclient": "^6.1.3"


### PR DESCRIPTION
Updated DTDL language server to 0.6.1

Updated version to 1.4.1 for release